### PR TITLE
Switch from PubSub to SignalR; add Refund to TransactionType

### DIFF
--- a/PhotonPiano.Api/Configurations/OpenApiSecuritySchemeTransformer.cs
+++ b/PhotonPiano.Api/Configurations/OpenApiSecuritySchemeTransformer.cs
@@ -16,7 +16,6 @@ public class OpenApiSecuritySchemeTransformer
         {
             Name = "PhotonPiano",
             Email = "PhotonPiano@gmail.com"
-            //Url = new Uri(@"https://learn2drive-v2.vercel.app/")
         };
 
         var securitySchema =

--- a/PhotonPiano.Api/Program.cs
+++ b/PhotonPiano.Api/Program.cs
@@ -20,7 +20,7 @@ builder.Services.AddApiDependencies(configuration)
     .AddBusinessLogicDependencies()
     .AddDataAccessDependencies();
 
-builder.AddPubSub();
+builder.AddSignalRConfig();
 
 builder.Services.AddSingleton<RedirectUrlValidator>();
 
@@ -59,7 +59,7 @@ app.UseExceptionHandler();
 
 app.UseAuthorization();
 
-app.MapPubSub();
+app.MapSignalRConfig();
 
 app.UseResponseCompression();
 

--- a/PhotonPiano.DataAccess/Models/Enum/StudentStatus.cs
+++ b/PhotonPiano.DataAccess/Models/Enum/StudentStatus.cs
@@ -6,6 +6,6 @@ public enum StudentStatus
     AttemptingEntranceTest,
     WaitingForClass,
     InClass,
-    DropOut,
-    Leave
+    DropOut, // buoc thoi hoc
+    Leave // tu nguyen 
 }

--- a/PhotonPiano.DataAccess/Models/Enum/TransactionType.cs
+++ b/PhotonPiano.DataAccess/Models/Enum/TransactionType.cs
@@ -4,4 +4,5 @@ public enum TransactionType
 {
     EntranceTestFee,
     TutionFee,
+    Refund
 }

--- a/PhotonPiano.PubSub/AppBuilderExtensions.cs
+++ b/PhotonPiano.PubSub/AppBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace PhotonPiano.PubSub;
 
 public static class AppBuilderExtensions
 {
-    public static void AddPubSub(this WebApplicationBuilder builder, Action<PubSubConfig> configure = null)
+    public static void AddSignalRConfig(this WebApplicationBuilder builder, Action<PubSubConfig> configure = null)
     {
         if (builder is null)
             throw new ArgumentNullException(nameof(builder));
@@ -25,7 +25,7 @@ public static class AppBuilderExtensions
         builder.Services.AddSingleton<INotificationServiceHub, NotificationServiceHub>();
     }
 
-    public static void MapPubSub(this WebApplication app)
+    public static void MapSignalRConfig(this WebApplication app)
     {
         if (app is null)
             throw new ArgumentNullException(nameof(app));


### PR DESCRIPTION
Replaced PubSub methods with SignalR methods in Program.cs and AppBuilderExtensions.cs to switch real-time communication from PubSub to SignalR. Removed a commented-out URL line in OpenApiSecuritySchemeTransformer.cs. Added Vietnamese comments to DropOut and Leave statuses in StudentStatus enum. Added a new Refund value to TransactionType enum.