### PR TITLE
Add Docker image push step to deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
         run: docker build -t ${{ env.IMAGE_NAME }}:latest -t ${{ env.IMAGE_NAME }}:${{ github.sha }} -f PhotonPiano.Api/Dockerfile .
 
       - name: Push Docker Images
+        if: success()
         run: |
           docker push ${{ env.IMAGE_NAME }}:latest
           docker push ${{ env.IMAGE_NAME }}:${{ github.sha }}


### PR DESCRIPTION
This commit introduces a new step in the `deploy.yml` file that pushes the built Docker images to a registry. The push operation is conditional on the success of previous steps and includes commands to push both the `latest` tag and the tag corresponding to the current Git commit SHA.