### PR TITLE
Add comment for PostgreSQL container password

### DIFF
--- a/PhotonPiano.Test/Extensions/IntergrationTestWebAppFactory.cs
+++ b/PhotonPiano.Test/Extensions/IntergrationTestWebAppFactory.cs
@@ -17,7 +17,7 @@ public class IntergrationTestWebAppFactory : WebApplicationFactory<Program>, IAs
         .WithImage("postgres:latest")
         .WithDatabase("photonpiano")
         .WithUsername("postgres")
-        .WithPassword("postgres")
+        .WithPassword("postgres") // This is the default password for the postgres image
         .Build();
 
     public async Task InitializeAsync()


### PR DESCRIPTION
Clarified the purpose of the password in the PostgreSQL container setup by adding a comment indicating that it is the default password for the postgres image. This improves code readability and provides context for future developers.